### PR TITLE
ADD CATEGORY FILTERS TO SERVICES PAGE

### DIFF
--- a/components/CategoryCheckboxFilter.js
+++ b/components/CategoryCheckboxFilter.js
@@ -1,0 +1,13 @@
+import { Checkbox } from "@chakra-ui/react";
+const CategoryCheckBoxFilter = (props) => {
+    return ( <Checkbox
+        color="white"
+        onClick={(e) => props.func(e)}
+        colorScheme={"teal"}
+        value={props.text}
+      >
+        {props.text}
+      </Checkbox>  );
+}
+ 
+export default CategoryCheckBoxFilter;

--- a/components/ServiceFilter.js
+++ b/components/ServiceFilter.js
@@ -1,0 +1,13 @@
+import { Select } from "@chakra-ui/react";
+
+const ServicesFilter = ({text=""}) => {
+  return (
+    <Select placeholder={text} w="100%">
+      <option value="option1">Option 1</option>
+      <option value="option2">Option 2</option>
+      <option value="option3">Option 3</option>
+    </Select>
+  );
+};
+
+export default ServicesFilter;

--- a/components/ServiceFilterDrawer.js
+++ b/components/ServiceFilterDrawer.js
@@ -1,0 +1,94 @@
+import React from "react";
+import {
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerHeader,
+  Input,
+  Button,
+  useDisclosure,
+  Box,
+  VStack,
+  Checkbox,
+  Text,
+} from "@chakra-ui/react";
+import ServicesFilter from "./ServiceFilter";
+
+function ServicesFilterDrawer() {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const btnRef = React.useRef();
+
+  const filterList = (e) => {
+    e.preventDefault()
+    
+    console.log(e.target.value)
+  };
+
+  return (
+    <>
+      <Button ref={btnRef} colorScheme="teal" onClick={onOpen}>
+        Filter Services
+      </Button>
+      <Drawer
+        isOpen={isOpen}
+        placement="left"
+        onClose={onClose}
+        finalFocusRef={btnRef}
+      >
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerCloseButton />
+          <DrawerHeader>Filter Services</DrawerHeader>
+
+          <DrawerBody>
+            <Box px={5} py={3}>
+              <VStack
+                my={5}
+                w={"100%"}
+                gap={3}
+                justifyContent={"flex-start"}
+                alignItems
+              >
+                <Checkbox
+                  color="white"
+                  onClick={(e) => filterList(e)}
+                  colorScheme={"teal"}
+                >
+                  Routine Labs
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Infectious Disease
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Diabetes Screen
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Clotting Screen
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Urine Based Tests
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Blood Based Tests
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Clotting Screen
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Job Onboarding
+                </Checkbox>
+                <Checkbox color="white" colorScheme={"teal"}>
+                  Clotting Screen
+                </Checkbox>
+              </VStack>
+            </Box>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+}
+
+export default ServicesFilterDrawer;

--- a/components/ServicesList/ServicesListItem.js
+++ b/components/ServicesList/ServicesListItem.js
@@ -33,21 +33,13 @@ const ServicesListItem = (props) => {
       mb={5}
     >
       <HStack justifyContent={"space-between"} w={"100%"}>
-        <Link
-          key={Math.random().toString()}
-          href={{
-            pathname: "/services/[slug]",
-            query: { slug: props.service.slug },
-          }}
-          replace
-        >
+      
           <Text fontSize={{ base: "1rem", lg: "1.75rem" }} fontWeight={700}>
             {props.service.name}
           </Text>
-        </Link>
         <Button
           onClick={() => router.push(`/services/${props.service.slug}`)}
-          replace
+          replace="true"
         >
           Learn More
         </Button>

--- a/components/layout/AllServicesPageSection.js
+++ b/components/layout/AllServicesPageSection.js
@@ -22,7 +22,7 @@ const AllServicesPageSection = () => {
         <Text as="h1" fontWeight={700} fontSize={"xx-large"}>
           Need Something Else?
         </Text>
-        <Button onClick={() => router.push(`/services`)} replace>
+        <Button onClick={() => router.push(`/services`)} >
           View All Services
         </Button>
       </VStack>

--- a/components/layout/Navigation.js
+++ b/components/layout/Navigation.js
@@ -14,6 +14,7 @@ import {
   useDisclosure,
   Container,
 } from "@chakra-ui/react";
+import { useRouter } from "next/router";
 import Image from "next/image";
 import GlobalSearch from "../GlobalSearch";
 import Logo from "../../public/logo.png";
@@ -27,6 +28,7 @@ const Navigation = (props) => {
   const [show, setShow] = React.useState(false);
   const handleToggle = () => setShow(!show);
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const router = useRouter();
 
   return (
     <Container w="100%" maxW={{ base: "100%", md: "65%", lg: "80%" }}>
@@ -43,9 +45,9 @@ const Navigation = (props) => {
       >
         <HStack>
           <Flex h="100%" mr={{base: 0, lg: 10}}>
-            <Link href="/" border={"1px solid white"}>
-              <Image src={Logo} />
-            </Link>
+            {/* <Link href="/" border={"1px solid white"}> */}
+              <Image onClick={() => router.push(`/`)} src={Logo} />
+            {/* </Link> */}
           </Flex>
           <Show below="md">
             <GlobalSearch />
@@ -89,7 +91,7 @@ const Navigation = (props) => {
               </MenuItem>
               <MenuItem>
                 <Link href="/categories/infectious-disease">
-                  infectious Disease
+                  Infectious Disease
                 </Link>
               </MenuItem>
               <MenuItem>

--- a/components/layout/SideBarCategories.js
+++ b/components/layout/SideBarCategories.js
@@ -44,7 +44,6 @@ const SideBarCategories = (props) => {
             <Link
               key={Math.random().toString()}
               href={`/categories/${cat.slug}`}
-              replace
             >
               <Text as="p" fontSize={"xl"}>
                 {cat.name}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "axios": "^0.27.2",
         "cors": "^2.8.5",
         "express": "^4.18.1",
+        "formik": "^2.2.9",
         "framer-motion": "^6.5.1",
         "framer-motion-carousel": "^2.0.1",
         "next": "12.2.5",
@@ -3008,6 +3009,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -3921,6 +3930,39 @@
         "node": ">= 6"
       }
     },
+    "node_modules/formik": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
+      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://opencollective.com/formik"
+        }
+      ],
+      "dependencies": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/formik/node_modules/react-fast-compare": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+    },
+    "node_modules/formik/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -4750,6 +4792,16 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -6173,6 +6225,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "node_modules/tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
@@ -8660,6 +8717,11 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "deepmerge": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz",
+      "integrity": "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+    },
     "define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
@@ -9335,6 +9397,32 @@
         "mime-types": "^2.1.12"
       }
     },
+    "formik": {
+      "version": "2.2.9",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz",
+      "integrity": "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==",
+      "requires": {
+        "deepmerge": "^2.1.1",
+        "hoist-non-react-statics": "^3.3.0",
+        "lodash": "^4.17.21",
+        "lodash-es": "^4.17.21",
+        "react-fast-compare": "^2.0.1",
+        "tiny-warning": "^1.0.2",
+        "tslib": "^1.10.0"
+      },
+      "dependencies": {
+        "react-fast-compare": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
+          "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
+      }
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -9904,6 +9992,16 @@
       "requires": {
         "p-locate": "^5.0.0"
       }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -10835,6 +10933,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
       "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
     },
     "to-fast-properties": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^0.27.2",
     "cors": "^2.8.5",
     "express": "^4.18.1",
+    "formik": "^2.2.9",
     "framer-motion": "^6.5.1",
     "framer-motion-carousel": "^2.0.1",
     "next": "12.2.5",

--- a/testanywhere-db-default-rtdb-export (1).json
+++ b/testanywhere-db-default-rtdb-export (1).json
@@ -1,0 +1,563 @@
+{
+  "data": {
+    "categories": [
+      {
+        "id": "c1",
+        "name": "Routine Labs",
+        "slug": "routine-labs"
+      },
+      {
+        "id": "c2",
+        "name": "Infectious Disease",
+        "slug": "infectious-disease"
+      },
+      {
+        "id": "c3",
+        "name": "Diabetes Screen",
+        "slug": "diabetes-screening"
+      },
+      {
+        "id": "c4",
+        "name": "Clotting Screen",
+        "slug": "clotting-screening"
+      },
+      {
+        "id": "c5",
+        "name": "Urine Based Tests",
+        "slug": "urine-based-testing"
+      },
+      {
+        "id": "c6",
+        "name": "Job Onboarding",
+        "slug": "job-onboarding"
+      },
+      {
+        "id": "c7",
+        "name": "Womens' Health",
+        "slug": "womens-health"
+      },
+      {
+        "id": "c8",
+        "name": "Immunizations",
+        "slug": "immunizations"
+      },
+      {
+        "id": "c9",
+        "name": "Test Bundles",
+        "slug": "test-bundles"
+      }
+    ],
+    "services": [
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660140015/web_images_1_lk8k4v.png",
+        "bulletpoints": [
+          "Albumin - Albumin is a protein made by the liver. Measuring levels of albumin is helpful in diagnosing liver disease. An albumin test measures how well your liver is making the proteins that your body needs.",
+          "Alanine aminotransferase (ALT) - ALT is an enzyme found predominantly in the cells of the liver. When the liver is damaged, ALT rises.",
+          "Alkaline Phosphatase - In conditions affecting the liver, damaged liver cells release increased amounts of ALP into the blood.",
+          "Aspartate aminotransferase (AST) - AST is another liver enzyme that is useful in helping to diagnose liver diseases.  Unlike ALT, it can be elevated from other causes as well.",
+          "Blood urea nitrogen (BUN) - Urea nitrogen is a byproduct from the breakdown of food proteins. A normal BUN level is between 7 and 20. As kidney function decreases, the BUN level rises.",
+          "Calcium - Measuring calcium can help determine whether the kidneys are excreting the proper amount of calcium and can also help diagnose kidney stones.",
+          "Carbon dioxide (Bicarbonate) - Your kidneys and lungs balance the levels of carbon dioxide, bicarbonate, and carbonic acid in the blood. Carbon dioxide levels can be used to help diagnose kidney disease.",
+          "Chloride - Chloride is an electrolyte. An increased level of blood chloride may indicate kidney disease.",
+          "Creatinine with estimated GFR - A waste product that comes from the normal wear and tear on muscles of the body. This test is a measure of how well the kidneys are removing wastes and excess fluid from the blood. The normal value for GFR is 90 or above, but may decrease with age. A GFR below 60 is a sign that the kidneys are not working properly. A GFR below 15 indicates kidney failure.",
+          "Glucose - Also known as blood sugar, is the body's main source of energy, and is typically used by physicians to diagnose and monitor patients for prediabetes, diabetes (Type 1, Type 2, and gestational), hyperglycemia, and hypoglycemia.",
+          "Potassium - Potassium is an electrolyte. High blood potassium can occur secondary to kidney disease.  Low blood potassium can happen with vomiting or diarrhea or the use of water pills.",
+          "Sodium - Sodium is an electrolyte. Abnormal levels of sodium help to determine if the kidneys are properly removing sodium from the body",
+          "Total bilirubin - This test measures direct and indirect levels of bilirubin to calculate a total bilirubin value.  Excess bilirubin, caused by obstruction or an inflamed liver, can lead to jaundice. Jaundice can cause your skin and the whites of your eyes to yellow.",
+          "Total protein - Total protein, the amount of protein in your blood, can help diagnose liver disease. The two main proteins found in the blood are globulins and albumin."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}, {"name": "Diabetes Screen", "slug": "diabetes-screen"}],
+        "id": "s0",
+        "monitors": "",
+        "name": "Comprehensive Metabolic Panel",
+        "price": 49,
+        "slug": "comprehensive-metabolic-panel",
+        "summary": "The comprehensive metabolic panel (CMP) measures blood sugar (glucose) levels, electrolyte and fluid balance, kidney function, and liver function.  The CMP is a snapshot of your overall health and its metabolism and chemical balance. It helps providers to diagnose certain conditions like diabetes, kidney disease, liver disease, hypertension. It’s often used for annual health exams.",
+        "tags": [
+          "Routine Labs",
+          "Diabetes Screen"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660140120/web_images_1_1_sfpase.png",
+        "bulletpoints": [
+          "Calcium - This test checks to make sure that your kidneys are producing the proper amount of calcium. Testing for calcium can sometimes help diagnose kidney stones.",
+          "Carbon Dioxide - The blood’s carbon dioxide levels are monitored and balanced by your lungs and kidneys. Looking at carbon dioxide levels can help to diagnose kidney disease.",
+          "Chloride - Chloride is one of the most important electrolytes in your blood. An increased level of blood chloride may indicate kidney disease or adrenal gland problems. Chloride helps to maintain your body’s proper blood volume and blood pressure. Most importantly, chloride keeps the ration of fluids inside and outside of your body’s cells at balance.",
+          "Creatinine to Bun Ratio (calculated) - The ratio of creatinine to BUN is usually between 10:1 and 20:1. A higher ratio may be caused by a condition that leads to a decrease in blood flow to the kidneys.",
+          "Glucose - A glucose test measures the amount of a certain kind of sugar (glucose)that's in your blood. High blood glucose levels can lead to damaged eyes, kidneys, blood vessels, and nerves.",
+          "Potassium - Potassium is both an electrolyte and a mineral. Potassium regulates the fluid ratio inside of your body and outside of your body. Potassium is a significant factor when it comes to keeping your nerves and muscles working. Kidney disease is the most common cause of high blood potassium.",
+          "Sodium - Sodium, like potassium, is also both an electrolyte and a mineral. Sodium is primarily located in the blood and lymph fluid. A hormone called aldosterone is created by adrenal glands to communicate with your kidneys and let them know how much sodium needs to be passed into the urine. When your sodium levels are low, it could mean heart failure.",
+          "Blood Urea Nitrogen (BUN) - Blood urea nitrogen is a byproduct of the breakdown of food proteins. Urea is created in the liver and passed out of your body through urine. A normal BUN level varies from 7 to 20. High BUN levels usually mean a decrease in kidney function."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}, {"name": "Diabetes Screen", "slug": "diabetes-screen"}],
+        "id": "s1",
+        "monitors": "BUN, Ca, Cl, CRE, GLU, K, Na",
+        "name": "Basic Metabolic Panel",
+        "price": 39,
+        "slug": "basic-metabolic-panel",
+        "summary": "Basic Metabolic Panel (BMP) measures your blood’s electrolyte and fluid balance, glucose levels, and your overall kidney function.",
+        "tags": [
+          "Routine Labs",
+          "Diabetes Screen"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362743/national-cancer-institute-eo_4DqPUSQA-unsplash_bo6kmb.jpg",
+        "bulletpoints": [
+          "Total Cholesterol: The total amount of cholesterol in your blood.",
+          "LDL “Bad Cholesterol”: Low-density lipoprotein cholesterol, this is known as bad cholesterol because it can lead to a hardening and clogging of your arteries.",
+          "HDL “Good cholesterol”: High-density lipoprotein cholesterol, this type of cholesterol helps to remove LDL from your blood.",
+          "Triglycerides: Unused calories are stored by the body as triglycerides in fat (lipid) cells."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s2",
+        "monitors": "CHOL, CHOL/HDL, nHDLc, HDL, LDL, TRIG, VLDL",
+        "name": "Lipid Panel",
+        "price": 29,
+        "slug": "lipid-panel",
+        "summary": "This panel is a snapshot of your overall cholesterol levels and triglycerides (the main components of natural fats and oils). Lipids are a type of fat and fat-like substances found in cells and are used as a source of energy like glucose. Cholesterol and triglycerides are the main things tested in this panel. Monitoring and maintaining proper cholesterol levels is important to your health because the extra cholesterol may be deposited on the walls of blood vessels as plaque, which can narrow or even block blood vessels and lead to heart disease or stroke.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362774/cdc-aHUMtDA4-28-unsplash_ttllvz.jpg",
+        "bulletpoints": [
+          "Alanine aminotransferase (ALT/SGPT) - ALT is an enzyme found predominantly in the cells of the liver. When the liver is damaged, ALT is released into the blood.",
+          "Aspartate aminotransferase (AST/SGOT) - AST is a liver enzyme that is useful in helping to diagnose liver diseases.",
+          "Total Cholesterol: The total amount of cholesterol in your blood.",
+          "LDL “Bad Cholesterol”: Low-density lipoprotein cholesterol, this is known as bad cholesterol because it can lead to a hardening and clogging of your arteries.",
+          "HDL “Good cholesterol”: High-density lipoprotein cholesterol, this type of cholesterol helps to remove LDL from your blood.",
+          "Triglycerides: Unused calories are stored by the body as triglycerides in fat (lipid) cells.",
+          "VLDL stands for very-low-density lipoprotein: Your liver makes VLDL and releases it into your bloodstream. The VLDL particles mainly carry triglycerides, another type of fat, to your tissues. VLDL is similar to LDL cholesterol, but LDL mainly carries cholesterol to your tissues instead of triglycerides."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s3",
+        "monitors": "ALT, AST, CHOL, CHOL/HDL, nHDLc, GLU, HDL, LDL, TRIG, VLDL",
+        "name": "Lipid Panel Plus",
+        "price": 49,
+        "slug": "lipid-panel-plus",
+        "summary": "This test provides an overall look at your cholesterol, triglycerides, glucose and a basic snapshot of your liver function. Lipids are a type of fat and fat-like substances found in cells and are used as a source of energy like glucose. Cholesterol and triglycerides are the main things tested in this panel. Monitoring and maintaining proper cholesterol levels is important to your health because the extra cholesterol may be deposited on the walls of blood vessels as plaque, which can narrow or even block blood vessels and lead to heart disease or stroke. The liver filters the blood coming from the digestive tract, before passing it along to the rest of the body. This organ also detoxifies chemicals and metabolizes drugs and secretes bile that ends up back in the intestines. The liver also makes proteins that are important for blood clotting and other functions.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362774/cdc-aHUMtDA4-28-unsplash_ttllvz.jpg",
+        "bulletpoints": [
+          "Alanine aminotransferase (ALT/SGPT) - ALT is an enzyme found predominantly in the cells of the liver. When the liver is damaged, ALT is released into the blood.",
+          "Albumin - Albumin is a protein made by the liver. Measuring levels of albumin is helpful in diagnosing liver disease. An albumin test measures how well your liver is making the proteins that your body needs.",
+          "Alkaline phosphatase (ALP) - In conditions affecting the liver, damaged liver cells release increased amounts of ALP into the blood.",
+          "Aspartate aminotransferase (AST/SGOT) - AST is a liver enzyme that is useful in helping to diagnose liver diseases.",
+          "An amylase test (AMY) measures the amount of amylase in blood or urine (pee). Amylase is an enzyme made by your pancreas and salivary glands that helps your body break down carbohydrates. If an amylase test finds too much amylase in your blood or urine, it may indicate a pancreas disorder or other health condition.",
+          "Bilirubin, Total - This test measures direct and indirect levels of bilirubin for a total bilirubin value. In cases of an obstruction or inflamed liver, the liver cannot eliminate excess bilirubin. When the body has too much bilirubin, your skin and the whites of your eyes will start to yellow causing a condition called jaundice.",
+          "Gamma-glutamyl transferase (GGT)- is an enzyme that's mainly found in your liver. Healthcare providers use GGT blood tests to help diagnose liver conditions or to rule out certain medical conditions based on abnormal results from other liver enzyme tests.",
+          "Total Protein - Total protein measurements can help diagnose liver diseases. Total Protein measures the amount of protein in your blood. The two main proteins found in the blood are globulins and albumin."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s4",
+        "monitors": "ALB, ALP, ALT, AMY, AST, GGT, TBIL, TP",
+        "name": "Liver Panel Plus",
+        "price": 49,
+        "slug": "liver-panel-plus",
+        "summary": "The liver panel plus includes several tests that measure specific proteins and liver enzymes to get an overall sense of how well the liver is working.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362803/national-cancer-institute-vRbPz2qWkaA-unsplash_j167t8.jpg",
+        "bulletpoints": [
+          "Alanine aminotransferase (ALT/SGPT) - ALT is an enzyme found predominantly in the cells of the liver. When the liver is damaged, ALT is released into the blood.",
+          "Aspartate aminotransferase (AST/SGOT) - AST is a liver enzyme that is useful in helping to diagnose liver diseases.",
+          "Blood Urea Nitrogen (BUN) - Blood urea nitrogen is a byproduct of the breakdown of food proteins. Urea is created in the liver and passed out of your body through urine. A normal BUN level varies from 7 to 20. High BUN levels usually mean a decrease in kidney function.",
+          "Creatinine to Bun Ratio (calculated) - The ratio of creatinine to BUN is usually between 10:1 and 20:1. A higher ratio may be caused by a condition that leads to a decrease in blood flow to the kidneys.",
+          "Gamma-glutamyl transferase (GGT)- is an enzyme that's mainly found in your liver. Healthcare providers use GGT blood tests to help diagnose liver conditions or to rule out certain medical conditions based on abnormal results from other liver enzyme tests.",
+          "Glucose - A glucose test measures the amount of a certain kind of sugar (glucose)that's in your blood. High blood glucose levels can lead to damaged eyes, kidneys, blood vessels, and nerves."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s4",
+        "monitors": "ALT, AST, BUN, CRE, GGT, GLU",
+        "name": "General Chemistry 6",
+        "price": 49,
+        "slug": "general-chemistry-6",
+        "summary": "This test gives you a general snapshot of your overall health. It allows the provider to determine if they need to take a closer look at the function of your liver and kidney, and if you’re at potential risks for developing Type 2 diabetes. ",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362823/trust-tru-katsande-6q5QG8iIgRo-unsplash_basuey.jpg",
+        "bulletpoints": [
+          "Alanine aminotransferase (ALT/SGPT) - ALT is an enzyme found predominantly in the cells of the liver. When the liver is damaged, ALT is released into the blood.",
+          "Albumin - Albumin is a protein made by the liver. Measuring levels of albumin is helpful in diagnosing liver disease. An albumin test measures how well your liver is making the proteins that your body needs.",
+          "Alkaline phosphatase (ALP) - In conditions affecting the liver, damaged liver cells release increased amounts of ALP into the blood.",
+          "Aspartate aminotransferase (AST/SGOT) - AST is a liver enzyme that is useful in helping to diagnose liver diseases.",
+          "An amylase test (AMY) measures the amount of amylase in blood or urine (pee). Amylase is an enzyme made by your pancreas and salivary glands that helps your body break down carbohydrates. If an amylase test finds too much amylase in your blood or urine, it may indicate a pancreas disorder or other health condition.",
+          "LDL “Bad Cholesterol”: Low-density lipoprotein cholesterol, this is known as bad cholesterol because it can lead to a hardening and clogging of your arteries.",
+          "HDL “Good cholesterol”: High-density lipoprotein cholesterol, this type of cholesterol helps to remove LDL from your blood.",
+          "Triglycerides: Unused calories are stored by the body as triglycerides in fat (lipid) cells.",
+          "VLDL stands for very-low-density lipoprotein: Your liver makes VLDL and releases it into your bloodstream. The VLDL particles mainly carry triglycerides, another type of fat, to your tissues. VLDL is similar to LDL cholesterol, but LDL mainly carries cholesterol to your tissues instead of triglycerides.",
+          "Glucose - A glucose test measures the amount of a certain kind of sugar (glucose)that's in your blood. High blood glucose levels can lead to damaged eyes, kidneys, blood vessels, and nerves."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s5",
+        "monitors": "ALB, ALP, AMY, AST, CHOL, CHOL/HDL, nHDLc, GLU, HDL, LDL, TRIG, VLDL",
+        "name": "General Chemistry 13",
+        "price": 59,
+        "slug": "general-chemistry-13",
+        "summary": "This test gives a deeper look into your overall health. Like the General Chemistry 6, the General Chemistry 13 measures your glucose level, kidney function, and liver function. In addition, it measures your cholesterol levels.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362884/web_images_1_ij8un2.png",
+        "bulletpoints": [
+          "Carbon dioxide (Bicarbonate) - Your kidneys and lungs balance the levels of carbon dioxide, bicarbonate, and carbonic acid in the blood. Carbon dioxide levels can be used to help diagnose kidney disease.",
+          "Chloride - Chloride is an electrolyte. An increased level of blood chloride may indicate kidney disease.",
+          "Potassium - Potassium is both an electrolyte and a mineral. Potassium regulates the fluid ratio inside of your body and outside of your body. Potassium is a significant factor when it comes to keeping your nerves and muscles working. Kidney disease is the most common cause of high blood potassium.",
+          "Sodium - Sodium, like potassium, is also both an electrolyte and a mineral. Sodium is primarily located in the blood and lymph fluid. A hormone called aldosterone is created by adrenal glands to communicate with your kidneys and let them know how much sodium needs to be passed into the urine. When your sodium levels are low, it could mean heart failure."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s6",
+        "monitors": "Cl, K, Na, tCO2",
+        "name": "Electrolyte Panel",
+        "price": 29,
+        "slug": "electrolyte-panel",
+        "summary": "An electrolyte panel is a blood test that measures if there's an electrolyte imbalance in the body. Electrolytes are salts and minerals, such as sodium, potassium, chloride and bicarbonate, which are found in the blood. They can conduct electrical impulses in the body.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362919/web_images_1_1_xjkz8f.png",
+        "bulletpoints": [
+          "Blood Urea Nitrogen (BUN) - Blood urea nitrogen is a byproduct of the breakdown of food proteins. Urea is created in the liver and passed out of your body through urine. A normal BUN level varies from 7 to 20. High BUN levels usually mean a decrease in kidney function.",
+          "Creatinine to Bun Ratio (calculated) - The ratio of creatinine to BUN is usually between 10:1 and 20:1. A higher ratio may be caused by a condition that leads to a decrease in blood flow to the kidneys."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s7",
+        "monitors": "BUN, CRE",
+        "name": "Kidney Check",
+        "price": 49,
+        "slug": "kidney-check",
+        "summary": "This test gives you  an overall review of your kidney function.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362963/web_images_1_2_fgwg5r.png",
+        "bulletpoints": [
+          "Albumin is a protein found in the blood. If the kidneys are healthy, there should be very little protein in your urine – if any. However, if the kidneys are damaged, albumin may leak out of the kidneys and into your urine.",
+          "BUN (Blood Urea Nitrogen) - Urea nitrogen is a byproduct from the breakdown of food proteins. A normal BUN level is between 7 and 20. As kidney function decreases, the BUN level rises.",
+          "Calcium - Measuring calcium can help determine whether the kidneys are excreting the proper amount of calcium. Too much calcium can also help indicate kidney stones.",
+          "Carbon Dioxide - Your kidneys and lungs balance the levels of carbon dioxide, bicarbonate, and carbonic acid in the blood. High carbon dioxide levels can be used to help diagnose kidney disease.",
+          "Chloride - Chloride is an important electrolyte used by the body to maintain the proper blood volume, blood pressure, blood acidity, and balance of fluid in cells. An increased level of blood chloride may indicate kidney diseases like tubular acidosis, which is when the kidneys do not remove enough acid.",
+          "Creatinine - A waste product that comes from normal wear and tear on the body’s muscles. Creatinine levels in the blood vary depending on age, race, and body size, but a creatinine level greater than 1.2 for women or greater than 1.4 for men may be an indicator that the kidneys are not working properly. The level of creatinine in the blood rises as kidney disease progresses.",
+          "Glucose - Abnormally high levels of glucose in your blood (hyperglycemia) can indicate glycosuria. Renal glycosuria occurs when the renal tubules fail to reabsorb all glucose at a level that is normal.",
+          "Phosphorus - Functioning kidneys can remove extra phosphorus from your blood. Individuals with chronic kidney disease often cannot remove phosphorus from the blood very well. High phosphorus levels can cause damage to your body.",
+          "Potassium - Potassium is an electrolyte that assists in many bodily functions like water balance, digestion, and nerve impulses. Kidney disease can cause both high and low potassium levels",
+          "Sodium - Sodium is the final of the three major electrolytes your body utilizes to control fluid balance inside and out of cells, among other functions. High sodium levels could indicate kidney disease because the body is unable to effectively remove the correct amount.dney-related issues."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s8",
+        "monitors": "ALB, BUN, Ca, Cl, CRE, GLU, K, Na, PHOS, tCO2",
+        "name": "Renal Function Panel",
+        "price": 59,
+        "slug": "renal-function-panel",
+        "summary": "Our Renal Function Test Panel includes ten measurements that provide information necessary to determine your kidney health. Your kidneys filter over 180 liters of blood every day, removing waste and excess water. Without your kidneys filtering ability, the unwanted waste and water would accumulate in your blood and cause damage. By taking this test, a doctor can use the information gathered to help diagnose diseases.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363283/ousa-chea-gKUC4TMhOiY-unsplash_hdgsrf.jpg",
+        "bulletpoints": [
+          "Sodium - Sodium is the final of the three major electrolytes your body uCreatinine Kinase (CK)- this test measures the amount of creatine kinase (CK) in the blood. CK is a type of protein, known as an enzyme. It is mostly found in your skeletal muscles and heart, with lesser amounts in the brain. Skeletal muscles are the muscles attached to your skeleton. They work with your bones to help you move and give your body power and strength. Heart muscles pump blood in and out of the heart.",
+          "Creatinine - A waste product that comes from normal wear and tear on the body’s muscles. Creatinine levels in the blood vary depending on age, race, and body size, but a creatinine level greater than 1.2 for women or greater than 1.4 for men may be an indicator that the kidneys are not working properly. The level of creatinine in the blood rises as kidney disease progresses.",
+          "Glucose - Abnormally high levels of glucose in your blood (hyperglycemia) can indicate glycosuria. Renal glycosuria occurs when the renal tubules fail to reabsorb all glucose at a level that is normal.",
+          "Potassium - Potassium is an electrolyte that assists in many bodily functions like water balance, digestion, and nerve impulses. Kidney disease can cause both high and low potassium levels",
+          "Utilizes to control fluid balance inside and out of cells, among other functions. High sodium levels could indicate kidney disease because the body is unable to effectively remove the correct amount.dney-related issues.",
+          "Carbon Dioxide - Your kidneys and lungs balance the levels of carbon dioxide, bicarbonate, and carbonic acid in the blood. High carbon dioxide levels can be used to help diagnose kidney disease.",
+          "Chloride - Chloride is an important electrolyte used by the body to maintain the proper blood volume, blood pressure, blood acidity, and balance of fluid in cells. An increased level of blood chloride may indicate kidney diseases like tubular acidosis, which is when the kidneys do not remove enough acid."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s9",
+        "monitors": "BUN, CK, Cl, CRE, GLU, K, Na, tCO2",
+        "name": "Metlyte 8 Panel",
+        "price": 49,
+        "slug": "metlyte-8-panel",
+        "summary": "This test is a snapshot of your kidney function, metabolism and electrolyte balance. It also identifies measures for damage or disease of the skeletal muscles, heart or brain.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "bulletpoints": [
+          "Red Blood Cell Count (RBC) - Measures the amount of red blood cells (erythrocytes) in the blood. With the help of hemoglobin, red blood cells carry oxygen throughout the body.",
+          "White Blood Cell Count (WBC) - Detects the amount of white blood cells in the body. White blood cells fight off infections and foreign agents that may infect the body.",
+          "Mean Corpuscular Volume (MCV) - Finds the average size of red blood cells in the body. Coupled with the RDW, this will help the doctor determine how bad the condition is.",
+          "Hematocrit - Determines the amount of space red blood cells take up in the blood. This is affected by the size and number of red blood cells.",
+          "Hemoglobin (Hgb, Hb) - Measures the amount of hemoglobin in the blood. Hemoglobin is a protein found in red blood cells that carries oxygen from the lungs and transports it to the various tissues and organs throughout the body. It also transports carbon dioxide back to the lungs to be converted into oxygen.",
+          "Platelet Count - Identifies the amount of platelets in the blood. Platelets are used to help form blood clots and regenerate new tissue.",
+          "Mean Corpuscular Volume (MCV) - Finds the average size of red blood cells in the body. Coupled with the RDW, this will help the doctor determine how bad the condition is."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s10",
+        "monitors": "RBC, WBC, HGB, HCT, PLT, MCV",
+        "name": "Complete Blood Count",
+        "price": 29,
+        "slug": "complete-blood-count",
+        "summary": "The Complete Blood Count (CBC) test gives an overall view of general health by measuring the health of red blood cells, white blood cells, and platelets. These cells, respectively, provide oxygen to various tissues and organs, help the immune system fight off infections, and assist in the formation of blood clots and the regeneration of new tissues.",
+        "tags": [
+          "Routine Labs"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363320/cdc-wCo9UwZEa18-unsplash_upkdsp.jpg",
+        "bulletpoints": [
+          "Acidity (pH) - The pH level indicates the amount of acid in urine. The pH level might indicate a kidney or urinary tract disorder.",
+          "Concentration - A measure of concentration shows how concentrated the particles are in your urine. A higher than normal concentration often is a result of not drinking enough fluids.",
+          "Protein - Low levels of protein in urine are typical. Small increases in protein in urine usually aren't a cause for concern, but larger amounts might indicate a kidney problem.",
+          "Sugar - The amount of sugar (glucose) in urine is typically too low to be detected. Any detection of sugar on this test usually calls for follow-up testing for diabetes.",
+          "Ketones - As with sugar, any amount of ketones detected in your urine could be a sign of diabetes and requires follow-up testing.",
+          "Bilirubin - Bilirubin is a product of red blood cell breakdown. Usually, bilirubin is carried in the blood and passes into your liver, where it's removed and becomes part of bile. Bilirubin in your urine might indicate liver damage or disease.",
+          "Evidence of infection - Either nitrites or leukocyte esterase — a product of white blood cells — in your urine might indicate a urinary tract infection.",
+          "Blood - Blood in your urine requires additional testing. It may be a sign of kidney damage, infection, kidney or bladder stones, kidney or bladder cancer, or blood disorders."
+        ],
+        "categories": [{"name": "Routine Labs", "slug": "routine-labs"}, {"name": "Diabetes Screen", "slug": "diabetes-screen"}, {"name": "Urine Based Tests", "slug": "urine-based-testing"}],
+        "id": "s11",
+        "monitors": "",
+        "name": "Urinalysis",
+        "price": 29,
+        "slug": "urinalysis",
+        "summary": "A urinalysis is a common method of analyzing urine that is used to assess your health, and to help diagnose renal, systemic, inflammatory, and neoplastic diseases, as well as urinary tract infections and urinary tract neoplasms. Our routine urinalysis contains 12 different parts which analyze numerous levels and elements within urine. All positives found will undergo additional microscope examination. ",
+        "tags": [
+          "Diabetes Screen",
+          "Urine Based Tests",
+          "Routine Labs",
+          "Womens' Health"
+        ],
+        "whatToExpect": "Those who are taking this test should not drink excessive liquids before providing the urine sample. Some believe that drinking large amounts of water before a urine drug test can hide or reduce the chances of a positive result, but all this will do is risk invalidating the test. An official ID card will be needed."
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363283/ousa-chea-gKUC4TMhOiY-unsplash_hdgsrf.jpg",
+        "bulletpoints": [
+          "Blood Urea Nitrogen (BUN) - Blood urea nitrogen is a byproduct of the breakdown of food proteins. Urea is created in the liver and passed out of your body through urine. A normal BUN level varies from 7 to 20. High BUN levels usually mean a decrease in kidney function.",
+          "Creatinine to Bun Ratio (calculated) - The ratio of creatinine to BUN is usually between 10:1 and 20:1. A higher ratio may be caused by a condition that leads to a decrease in blood flow to the kidneys."
+        ],
+        "categories": [{"name": "Diabetes Screen", "slug": "diabetes-screen"}],
+        "id": "s12",
+        "monitors": "",
+        "name": "Hemoglobin A1C",
+        "price": 29,
+        "slug": "hemoglobin-a1c",
+        "summary": "The Hemoglobin A1C test evaluates the average amount of glucose in the blood over an 8-12 week time span by examining how thick the coat of glucose is that is bound to the blood's hemoglobin (or blood sugar levels). When the two bind, the hemoglobin gets a coat of sugar around it. The coat thickens as the amount of glucose in the blood increases. The hemoglobin A1C test measures for HbA1C, a subtype of hemoglobin. **** After a diabetes diagnosis, this test is often recommended four times per year if glycemic goals are not met. If the glycemic control is stable, then twice per year. Those with diabetes often must take extra care to keep their glucose levels as close to normal as possible. Chronically high glucose levels lead to problems like damage to the kidneys, eyes, cardiovascular system, and nerves.",
+        "tags": [
+          "Diabetes Screen"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "bulletpoints": [
+          "6-Acetyl Morphine (6-AM)",
+          "Marijuana (THC)",
+          "Cocaine",
+          "Amphetamines",
+          "Opiates (including Hydrocodone, Hydromorphone, Codeine, and Morphine)",
+          "Phencyclidine (PCP)",
+          "Barbiturates",
+          "Benzodiazepines",
+          "MDMA (Ecstasy/Molly)",
+          "Methadone",
+          "Methaqualone (Quaaludes)",
+          "Propoxyphene"
+        ],
+        "categories": [{"name": "Urine Based Tests", "slug": "urine-based-testing"}],
+        "id": "s13",
+        "monitors": "6-Acetyl Morphine, THC, Cocaine, Amphetamines, Opiates, PCP, MDMA, etc.",
+        "name": "12 Panel Drug Test",
+        "price": 59,
+        "slug": "12-panel-drug-test",
+        "summary": "This 12-panel drug test is used to check for the presence of drug abuse through a urine sample. This test covers more prescription drugs that are often abused, in addition to the most popular illicit drugs. Illicit drugs, also known as street drugs or simply illegal drugs, are almost never prescribed.",
+        "tags": [
+          "Urine Based Tests",
+          "Job Onboarding"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363320/cdc-wCo9UwZEa18-unsplash_upkdsp.jpg",
+        "bulletpoints": [
+          "Lipid and Cholesterol Panel: Measures cholesterol levels to assess cardiovascular health and identify one’s risk for developing cardiovascular disease.",
+          "Comprehensive Metabolic Panel (CMP): Measures substances (proteins, enzymes, electrolytes, etc.) to assess the body’s overall health by looking at metabolism (how the body breaks down and uses food and liquids to provide energy for cells).",
+          "Routine Urinalysis: Identifies signs of various illnesses and conditions, including urinary tract infections (UTIs), kidney disease, and diabetes."
+        ],
+        "categories": [{"name": "Test Bundles", "slug": "test-bundles"}, {"name": "Diabetes Screen", "slug": "diabetes-screen"}, {"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s14",
+        "monitors": "CMP, UA, Lipid panel (choose 2)",
+        "name": "Basic Health Panel",
+        "price": 59,
+        "slug": "basic-health-panel",
+        "summary": "Our basic health panel helps evaluate how well certain organs and bodily systems are working. The results from this test can help providers to identify potential concerns that could negatively impact your health in the future. For example high glucose could indicate a risk of developing diabetes or high cholesterol could indicate a risk of developing cardiovascular disease in the future.",
+        "tags": [
+          "Test Bundles"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363414/akram-huseyn-fKC9eWRnlGY-unsplash_vilofs.jpg",
+        "bulletpoints": [
+          "Lipid and Cholesterol Panel: Measures cholesterol levels to assess cardiovascular health and identify one’s risk for developing cardiovascular disease.",
+          "Comprehensive Metabolic Panel (CMP): Measures substances (proteins, enzymes, electrolytes, etc.) to assess the body’s overall health by looking at metabolism (how the body breaks down and uses food and liquids to provide energy for cells).",
+          "Routine Urinalysis: Identifies signs of various illnesses and conditions, including urinary tract infections (UTIs), kidney disease, and diabetes.",
+          "The Complete Blood Count (CBC) with differential and platelets test helps to give an overall view of general health and screens for a broad scope of diseases and conditions. CBC testing is routinely recommended by doctors and can help doctors understand why patients may exhibit fatigue or easy bruising. It can even help them diagnose conditions such as anemia."
+        ],
+        "categories": [{"name": "Test Bundles", "slug": "test-bundles"}, {"name": "Diabetes Screen", "slug": "diabetes-screen"}, {"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s15",
+        "monitors": "CMP, UA, Lipid Panel, CBC (Choose 3)",
+        "name": "Standard Health Panel",
+        "price": 99,
+        "slug": "standard-health-panel",
+        "summary": "Our Standard Health Panel is a combination of tests that measure and evaluate the body as a whole. The results from this test can give providers a more in depth view of how your organs and if there are any potential risks of developing diseases in the future.",
+        "tags": [
+          "Test Bundles"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363438/rephile-water-cuqp2Jzz_lY-unsplash_c2icja.jpg",
+        "bulletpoints": [
+          "Lipid and Cholesterol Panel: Measures cholesterol levels to assess cardiovascular health and identify one’s risk for developing cardiovascular disease.",
+          "Comprehensive Metabolic Panel (CMP): Measures substances (proteins, enzymes, electrolytes, etc.) to assess the body’s overall health by looking at metabolism (how the body breaks down and uses food and liquids to provide energy for cells).",
+          "Routine Urinalysis: Identifies signs of various illnesses and conditions, including urinary tract infections (UTIs), kidney disease, and diabetes.",
+          "The Complete Blood Count (CBC) with differential and platelets test helps to give an overall view of general health and screens for a broad scope of diseases and conditions. CBC testing is routinely recommended by doctors and can help doctors understand why patients may exhibit fatigue or easy bruising. It can even help them diagnose conditions such as anemia.",
+          "Hemoglobin A1C test evaluates the average amount of glucose in the blood over an 8-12 week time span."
+        ],
+        "categories": [{"name": "Test Bundles", "slug": "test-bundles"}, {"name": "Diabetes Screen", "slug": "diabetes-screen"}, {"name": "Routine Labs", "slug": "routine-labs"}],
+        "id": "s16",
+        "monitors": "CBC, CMP, UA, Lipid Panel, HGA1C",
+        "name": "Comprehensive Health Panel",
+        "price": 139,
+        "slug": "comprehensive-health-panel",
+        "summary": "Our Comprehensive Health Panel is composed of blood measurements that are typically ordered by a provider during your annual primary care visit. This panel of tests will detect possible blood count ailments such as anemia, measure the function of your liver, kidneys, and thyroid as well as detect for risk of developing type 2 diabetes or heart disease.",
+        "tags": [
+          "Test Bundles"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362743/national-cancer-institute-eo_4DqPUSQA-unsplash_bo6kmb.jpg",
+        "categories": [{"name": "Infectious Disease", "slug": "infectious-disease"}],
+        "id": "s17",
+        "monitors": "",
+        "name": "COVID-19 Rapid-PCR swab (nasal)",
+        "price": 159,
+        "slug": "covid-19-rapid-test-pcr",
+        "summary": "This test has a higher sensitivity for the detection of Coronavirus (COVID-19). It can detect the presence of COVID-19 for up to 3 months even if you are no longer contagious. Coronavirus is a respiratory illness caused by a virus transmitted from person to person.",
+        "tags": [
+          "Infectious Disease",
+          "Job Onboarding"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660362823/trust-tru-katsande-6q5QG8iIgRo-unsplash_basuey.jpg",
+        "categories": [{"name": "Infectious Disease", "slug": "infectious-disease"}],
+        "id": "s18",
+        "monitors": "",
+        "name": "COVID-19 Rapid Antigen Test",
+        "price": "Varies",
+        "slug": "covid-19-rapid-antigen-test",
+        "summary": "The rapid antigen test can detect the presence of COVID when you have a higher amount of the virus particles in your system and are more contagious. This test typically can detect the presence of COVID-19 for up to 10-14 days after onset of symptoms.",
+        "tags": [
+          "Infectious Disease",
+          "Job Onboarding"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "categories": [{"name": "Infectious Disease", "slug": "infectious-disease"}],
+        "id": "s19",
+        "monitors": "",
+        "name": "Influenza (Flu) Test",
+        "price": 79,
+        "slug": "flu-test",
+        "summary": "Our rapid influenza test can detect the presence of Influenza A and B. influenza is a contagious respiratory illness caused by the Influenza virus. ",
+        "tags": [
+          "Infectious Disease"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "bulletpoints": [
+          "These vaccines contain material from the virus that causes COVID-19 that gives our cells instructions for how to make a harmless protein that is unique to the virus.",
+          "After our cells make copies of the protein, they destroy the genetic material from the vaccine.",
+          "Our bodies recognize that the protein should not be there and build T-lymphocytes and B-lymphocytes that will remember how to fight the virus that causes COVID-19 if we are infected in the future.",
+          "We offer Pfizer and Moderna for ages 5 and older."
+        ],
+        "categories": [{"name": "Immunizations", "slug": "immunizations"}],
+        "id": "s20",
+        "monitors": "",
+        "name": "COVID-19 Vaccination",
+        "price": "Free",
+        "slug": "covid-19-vaccination",
+        "tags": [
+          "Job Onboarding",
+          "Immunizations"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "categories": [{"name": "Womens' Health", "slug": "womens-health"}],
+        "id": "s21",
+        "monitors": "",
+        "name": "Pregnancy Test",
+        "price": 10,
+        "slug": "pregnancy-test",
+        "summary": "Our pregnancy test is a urine test that screens for the presence of human chorionic gonadotropin (hCG) in urine to aid in the detection of pregnancy",
+        "tags": [
+          "Urine Tests",
+          "Womens' Health"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "id": "s22",
+        "monitors": "",
+        "name": "Thyroid Stimulating Hormone",
+        "price": 29,
+        "slug": "thyroid-stimulating-hormone-test",
+        "summary": "The Thyroids Stimulating Hormone (TSH) test screens your body’s production of TSH. The thyroid regulates how well your body uses energy and produces hormones that are critical to proper organ and cell function. If you have recently been feeling tired or fatigue, excessive weight gain or difficulty conceiving? A TSH screen could possibly detect the presence of Hypothyroidism. If you have been experiencing excessive weight loss, hair loss, persistent vomiting, high blood pressure or fast heart rate, the TSH test could possibly reveal the presence of Hyperthyroidism.",
+        "tags": [
+          "Womens' Health"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "id": "s23",
+        "monitors": "",
+        "name": "Prothrombin Time (PT)/ International Normalized Ratio (INR) Clotting test",
+        "price": 39,
+        "slug": "ptinr-clotting-test",
+        "summary": "The Prothrombin (PT) and International Normalized Ratio clotting test measures the body’s ability to clot. This test is typically requested by providers to monitor patients taking blood thinning medications such as coumadin or heparin.",
+        "tags": [
+          "Clotting Screen"
+        ]
+      },
+      {
+        "bg": "https://res.cloudinary.com/dowmtolou/image/upload/v1660363292/national-cancer-institute-HMQtSQZHPZU-unsplash_hlqrbq.jpg",
+        "id": "s24",
+        "monitors": "",
+        "name": "Rapid Glucose Test",
+        "price": 39,
+        "slug": "rapid-glucose-test",
+        "summary": "Our Rapid Glucose test, also known as the Fasting Blood Glucose test, is most commonly used to diagnose Hyperglycemia and Diabetes. This test is a common clinical evaluation performed by your provider every year and during pregnancy. For best results, a fasting glucose is recommended, but not required. A fasting sample requires you to not consume any food or drink 8 hours prior to testing.",
+        "tags": [
+          "Womens' Health",
+          "Diabetes Screen",
+          "Routine Labs"
+        ]
+      }
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1783,6 +1783,11 @@
   "resolved" "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   "version" "0.1.4"
 
+"deepmerge@^2.1.1":
+  "integrity" "sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA=="
+  "resolved" "https://registry.npmjs.org/deepmerge/-/deepmerge-2.2.1.tgz"
+  "version" "2.2.1"
+
 "define-properties@^1.1.3", "define-properties@^1.1.4":
   "integrity" "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA=="
   "resolved" "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz"
@@ -2279,6 +2284,19 @@
     "asynckit" "^0.4.0"
     "combined-stream" "^1.0.8"
     "mime-types" "^2.1.12"
+
+"formik@^2.2.9":
+  "integrity" "sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA=="
+  "resolved" "https://registry.npmjs.org/formik/-/formik-2.2.9.tgz"
+  "version" "2.2.9"
+  dependencies:
+    "deepmerge" "^2.1.1"
+    "hoist-non-react-statics" "^3.3.0"
+    "lodash" "^4.17.21"
+    "lodash-es" "^4.17.21"
+    "react-fast-compare" "^2.0.1"
+    "tiny-warning" "^1.0.2"
+    "tslib" "^1.10.0"
 
 "forwarded@0.2.0":
   "integrity" "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
@@ -2794,6 +2812,11 @@
   dependencies:
     "p-locate" "^5.0.0"
 
+"lodash-es@^4.17.21":
+  "integrity" "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+  "resolved" "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz"
+  "version" "4.17.21"
+
 "lodash.merge@^4.6.2":
   "integrity" "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
   "resolved" "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
@@ -2803,6 +2826,11 @@
   "integrity" "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
   "resolved" "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz"
   "version" "4.6.2"
+
+"lodash@^4.17.21":
+  "integrity" "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+  "resolved" "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  "version" "4.17.21"
 
 "loose-envify@^1.0.0", "loose-envify@^1.1.0", "loose-envify@^1.4.0":
   "integrity" "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="
@@ -3224,6 +3252,11 @@
     "loose-envify" "^1.1.0"
     "scheduler" "^0.23.0"
 
+"react-fast-compare@^2.0.1":
+  "integrity" "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
+  "resolved" "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz"
+  "version" "2.0.4"
+
 "react-fast-compare@3.2.0":
   "integrity" "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
   "resolved" "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz"
@@ -3617,6 +3650,11 @@
   "resolved" "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz"
   "version" "1.2.0"
 
+"tiny-warning@^1.0.2":
+  "integrity" "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+  "resolved" "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz"
+  "version" "1.0.3"
+
 "to-fast-properties@^2.0.0":
   "integrity" "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
   "resolved" "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"
@@ -3655,6 +3693,11 @@
     "json5" "^1.0.1"
     "minimist" "^1.2.6"
     "strip-bom" "^3.0.0"
+
+"tslib@^1.10.0":
+  "integrity" "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+  "resolved" "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
+  "version" "1.14.1"
 
 "tslib@^1.8.1":
   "integrity" "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="


### PR DESCRIPTION
This commit applies a set of checkbox based filters to the sidebar of the Services page. I also created a ServiceFilterDrawer component, which is a button that triggers a drawer containing filters, for responsiveness

(testanywherelab #17)